### PR TITLE
add php phar settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM million12/nginx-php:latest
-MAINTAINER Marcin Ryzycki marcin@m12.io
+FROM million12/behat-selenium:latest
+MAINTAINER Jonas Renggli <jonas.renggli@swisscom.com>
 
 # - Install OpenSSH server
 # - Generate required host keys

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,18 @@ RUN \
   rm -rf /config/init/10-nginx-data-dirs.sh /etc/supervisor.d/nginx.conf /etc/supervisor.d/php-fpm.conf && \
   echo > /etc/sysconfig/i18n
 
+# - Install Node.js
+# - Install Grunt, Gulp, Yeoman
+# - Install Compass
+RUN \
+  yum install -y nodejs && \
+  yum clean all && \
+  npm install -g grunt-cli && \
+  gem install compass && \
+  npm install -g gulp && \
+  npm install -g yo
+
+ENV version=23
 # Add config/init scripts to run after container has been started
 ADD container-files /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM million12/php-app:latest
+FROM million12/nginx-php:latest
 MAINTAINER Marcin Ryzycki marcin@m12.io
 
 # - Install OpenSSH server

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
-# Docker container with SSH and PHP
-[![Circle CI](https://circleci.com/gh/million12/docker-php-app-ssh.svg?style=svg)](https://circleci.com/gh/million12/docker-php-app-ssh)
+# Docker container with SSH, PHP and Selenium meant for usage as Jenkins slave
 
-This is a Docker container [million12/php-app-ssh](https://registry.hub.docker.com/u/million12/php-app-ssh/) based on [million12/php-app](https://registry.hub.docker.com/u/million12/php-app/), with only one addition: running SSHD daemon. 
+This is a Docker container [sinso/jenkins-slave-php](https://registry.hub.docker.com/u/sinso/jenkins-slave-php/) based on [million12/behat-selenium](https://registry.hub.docker.com/u/million12/behat-selenium/) and [million12/php-app-ssh](https://registry.hub.docker.com/u/million12/php-app-ssh/). It maily combines the functionality of the last preceding containers and adds the possibility to configure public ssh keys (without using github)
 
-Because it shares the same container as other running PHP apps (if based on million12/php-app), it can be used for development purposes, to easily get into the container, perform command-line tasks (eg. composer install, npm, gulp), upload files via SFTP etc.
+Because it shares the same container as other running PHP apps (if based on million12/php-app), it can be used for continuous integration purposes, to easily build and run tests for TYPO3 Neos/Flow applications.
 
 ## Keys management
 
-SSH keys are added from GitHub via GitHub API. The only thing you need to do is to provide your username (or usernames, coma-separated) via env variable `IMPORT_GITHUB_PUB_KEYS`. Of course you need to have your pubkey added on your GitHub account.
+SSH keys are added from GitHub via GitHub API or can be set as an environment variable. The only thing you need to do is to provide your username (or usernames, coma-separated) via env variable `IMPORT_GITHUB_PUB_KEYS`. Of course you need to have your pubkey added on your GitHub account. To directly provide a public key just use the env variable `SSH_PUB_KEY`.
 
 ## Usage
 
-`docker run -d -p 1122:22 --volumes-from="webdata-container" --env="IMPORT_GITHUB_PUB_KEYS=user1,user2" million12/php-app-ssh`
+`docker run -d -p 1122:22 --env="IMPORT_GITHUB_PUB_KEYS=user1,user2" sinso/jenkins-slave-php`
+
+or
+
+`docker run -d -p 1122:22 --env="SSH_PUB_KEY=ssh-rsa AAAAB3NzaC....0uSCQ==" sinso/jenkins-slave-php`
 
 After container is launched, you can login:  
 `ssh -p 1122 www@docker-host`
@@ -26,12 +29,9 @@ dev:
     - webdata-container
   environment:
     IMPORT_GITHUB_PUB_KEYS: user1,user2,user3
+    SSH_PUB_KEY: 'ssh-rsa AAAAB3NzaC....0uSCQ=='
 ```
 
-## Author
+## Credits
 
-Marcin ryzy Ryzycki <marcin@m12.io>
-
----
-
-**Sponsored by** [Typostrap.io - the new prototyping tool](http://typostrap.io/) for building highly-interactive prototypes of your website or web app. Built on top of TYPO3 Neos CMS and Zurb Foundation framework.
+Thanks to the great work from Marcin ryzy Ryzycki <marcin@m12.io>

--- a/container-files/config/init/00-pwgen.sh
+++ b/container-files/config/init/00-pwgen.sh
@@ -20,3 +20,9 @@ else
     su www -c "/github-keys.sh $user"
   done
 fi
+
+if [ -z "${SSH_PUB_KEY+xxx}" ] || [ -z "${SSH_PUB_KEY}" ]; then
+  echo "WARNING: env variable \$SSH_PUB_KEY is not set. Please set it to have access to this container via SSH."
+else
+  su www -c "/ssh-key.sh \"${SSH_PUB_KEY}\""
+fi

--- a/container-files/etc/php.d/zzzz-phar.ini
+++ b/container-files/etc/php.d/zzzz-phar.ini
@@ -1,0 +1,6 @@
+[Phar]
+; http://php.net/phar.readonly
+phar.readonly = Off
+
+; http://php.net/phar.require-hash
+phar.require_hash = Off

--- a/container-files/ssh-key.sh
+++ b/container-files/ssh-key.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+#
+# Usage: /ssh-key.sh "ssh-rsa AAAAB3Nz..."
+#
+
+IFS="$(printf '\n\t')"
+
+key=$1
+
+echo "Importing pub key to `whoami` account..."
+
+mkdir -p ~/.ssh
+if ! [[ -f ~/.ssh/authorized_keys ]]; then
+  echo "Creating new ~/.ssh/authorized_keys"
+  touch ~/.ssh/authorized_keys
+fi
+
+echo "Import ssh key: $key" 
+grep -q "$key" ~/.ssh/authorized_keys || echo "$key imported_.key" >> ~/.ssh/authorized_keys


### PR DESCRIPTION
Hello @jrenggli 

So we need to be able to *create* PHAR files inside the build slave for our `graviton-deploy-scripts` build in Jenkins.
As stupid as it sounds; PHP actually ships with default settings *prohibiting* the creation of PHAR files - those 2 settings (well, at least `phar.readonly`) need to be changed for that..

*Why did I make two PRs?*
As you can see, this PR actually includes #2 - I just did 2 so you can merge as you wish - either only merge upstream first and then this one - or just merge this one and close #2.. as you wish..
Just thought it's cleaner to not mix it into one PR..