### PR TITLE
[TASK] Use parent docker image million12/docker-php-testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM million12/behat-selenium:latest
+FROM million12/php-testing:php56
 MAINTAINER Jonas Renggli <jonas.renggli@swisscom.com>
 
 # - Install OpenSSH server


### PR DESCRIPTION
The previous parent million12/behat-selenium is deprecated and got
replaced with million12/behat-selenium.

See: https://github.com/million12/docker-php-testing