### PR TITLE
Update to sitespeed.io 4.0.0-alpha5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN wget http://yslow.org/yslow-phantomjs-3.1.8.zip \
 	&& rm yslow-phantomjs-3.1.8.zip
 
 # install node stuff
-RUN npm install --unsafe-perm -g slimerjs@0.906.2 gulp grunt-cli yo sitespeed.io
+RUN npm install --unsafe-perm -g gulp grunt-cli yo sitespeed.io@04.0.0-alpha.5
 
 # Add config/init scripts to run after container has been started
 ADD container-files /


### PR DESCRIPTION
The 3.x version of sitespeed was depending on a version of slimerjs that is affected by https://github.com/graingert/slimerjs/issues/39#issuecomment-224910698.

After I realized that sitespeed has been in alpha for a while and that the new version is not affected I decided to try bumping and this seems to have fixed the build. I'm not sure about the downstream changes needed for the new sitespeed.io package though.